### PR TITLE
Fix TOTP from clipboard with existing content

### DIFF
--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/VerificationActivity.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/VerificationActivity.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import android.view.Window
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -28,6 +30,8 @@ class VerificationActivity : BaseAppCompatActivity(), Window.Callback {
         const val API_KEY = "apiKey"
         const val ACCOUNT = "account"
     }
+
+    private val DELAY_AFTER_RESET_MS = 100L
 
     private lateinit var binding: ActivityVerificationBinding
     private lateinit var verificationMode: VerificationMode
@@ -122,14 +126,17 @@ class VerificationActivity : BaseAppCompatActivity(), Window.Callback {
     }
 
     private fun pasteAndVerify(code: String) {
-        code.asIterable().forEach { char ->
-            addNumber(char.toString())
-        }
+        reset()
+        Handler(Looper.getMainLooper()).postDelayed({
+            code.asIterable().forEach { char ->
+                addNumber(char.toString(), false)
+            }
 
-        verify(code)
+            verify(code)
+        }, DELAY_AFTER_RESET_MS)
     }
 
-    private fun addNumber(number: String) {
+    private fun addNumber(number: String, launchVerify: Boolean = true) {
         when {
             binding.firstNumberTextView.text == dash -> {
                 binding.firstNumberTextView.text = number
@@ -149,7 +156,9 @@ class VerificationActivity : BaseAppCompatActivity(), Window.Callback {
                 code += binding.fifthNumberTextView.text
                 code += binding.sixthNumberTextView.text
 
-                verify(code)
+                if (launchVerify) {
+                    verify(code)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes: https://github.com/simple-login/Simple-Login-Android/issues/74

If the user clicked on the "Fill from clipboard" button, the previously existing input was not cleared, which made the app show the first N digits the user had entered, and the first (6-N) digits from the clipboard code.
The function that adds a number to the code has a check that, whenever the entered code reaches 6 numbers, it will launch a `verify` call.

However, the function that fills the code in the screen also performs a `verify` call (that means, two concurrent calls were sent at the same time), and when the first one fails (as it's using the wrong code), an error was displayed and the "wrong login attempt" e-mail was sent.
But as the second `verify` call succeeded, as it was using the code from the clipboard, the app will be correctly logged in.

The solution is the following:

1. Add a `reset()` call before filling the number from the clipboard, which clears the user-entered numbers.
2. Add a small 100ms delay after the reset call, so the UI can be updated accordingly (after manual testing, without that delay the user won't even percieve it.
3. Add a boolean flag to the `addNumber` function that allows us to control whether that function should perform the request (obtaining the text from the textviews) or not. In our case, as we have the code already available in the calling function (`pasteAndVerify`), there's no need to perform that extra step.

NOTE: As this project does not use Kotlin's coroutines, I've resorted to the old-known `Handler().postDelayed`