### PR TITLE
Implement Login with Proton

### DIFF
--- a/SimpleLogin/app/build.gradle
+++ b/SimpleLogin/app/build.gradle
@@ -83,6 +83,7 @@ dependencies {
     implementation "androidx.recyclerview:recyclerview:1.2.1"
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     implementation "androidx.biometric:biometric:1.1.0"
+    implementation "androidx.browser:browser:1.4.0"
 
     // Navigation
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.2'

--- a/SimpleLogin/app/src/main/AndroidManifest.xml
+++ b/SimpleLogin/app/src/main/AndroidManifest.xml
@@ -54,7 +54,22 @@
             android:theme="@style/HomeActivityTheme"
             android:windowSoftInputMode="adjustResize" />
         <activity android:name=".module.startup.LocalAuthActivity" />
-        <activity android:name=".module.login.LoginActivity" />
+
+        <!--
+            - exported="true": Needed for responding to external intents
+            - launchMode="singleTop": Reuse the same LoginActivity instance when receiving the auth.simplelogin callback
+        -->
+        <activity android:name=".module.login.LoginActivity"
+            android:exported="true"
+            android:launchMode="singleTop">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data android:scheme="auth.simplelogin"/>
+            </intent-filter>
+        </activity>
         <activity android:name=".module.login.VerificationActivity" />
         <activity android:name=".module.login.SignUpActivity" />
         <activity android:name=".module.login.AboutActivity" />

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/LoginActivity.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/LoginActivity.kt
@@ -2,26 +2,21 @@ package io.simplelogin.android.module.login
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.ComponentName
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
 import android.view.KeyEvent
 import android.view.View
 import androidx.browser.customtabs.CustomTabColorSchemeParams
-import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.browser.customtabs.CustomTabsServiceConnection
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.simplelogin.android.R
 import io.simplelogin.android.databinding.ActivityLoginBinding
 import io.simplelogin.android.module.home.HomeActivity
-import io.simplelogin.android.module.startup.StartupActivity
 import io.simplelogin.android.utils.SLApiService
 import io.simplelogin.android.utils.SLSharedPreferences
 import io.simplelogin.android.utils.baseclass.BaseAppCompatActivity
@@ -41,7 +36,6 @@ class LoginActivity : BaseAppCompatActivity() {
     }
 
     private lateinit var binding: ActivityLoginBinding
-    private var isShowingPassword = false
 
     // Forgot password
     private lateinit var forgotPasswordBottomSheetBehavior: BottomSheetBehavior<View>

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/LoginActivity.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/LoginActivity.kt
@@ -2,23 +2,34 @@ package io.simplelogin.android.module.login
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.content.ComponentName
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.KeyEvent
 import android.view.View
+import androidx.browser.customtabs.CustomTabColorSchemeParams
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsServiceConnection
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.simplelogin.android.R
 import io.simplelogin.android.databinding.ActivityLoginBinding
+import io.simplelogin.android.module.home.HomeActivity
+import io.simplelogin.android.module.startup.StartupActivity
 import io.simplelogin.android.utils.SLApiService
 import io.simplelogin.android.utils.SLSharedPreferences
 import io.simplelogin.android.utils.baseclass.BaseAppCompatActivity
 import io.simplelogin.android.utils.enums.*
 import io.simplelogin.android.utils.extension.*
+import io.simplelogin.android.utils.model.UserInfo
 import io.simplelogin.android.utils.model.UserLogin
+
 
 class LoginActivity : BaseAppCompatActivity() {
     companion object {
@@ -90,6 +101,10 @@ class LoginActivity : BaseAppCompatActivity() {
         binding.loginButton.isEnabled = false // disable login button by default
         binding.loginButton.setOnClickListener { login() }
 
+        binding.loginWithProtonButton.setOnClickListener {
+            loginWithProton()
+        }
+
         // Sign up
         binding.signUpButton.setOnClickListener {
             val signUpIntent = Intent(this, SignUpActivity::class.java)
@@ -130,6 +145,19 @@ class LoginActivity : BaseAppCompatActivity() {
             setResult(Activity.RESULT_CANCELED)
             finish()
         }
+    }
+
+    /**
+     * Callback for when the Login with Proton process is done.
+     * The Login with Proton will redirect the user to
+     * auth.simplelogin://callback?apikey=YOUR_API_KEY
+     *
+     * (The intent-filter is registered on the AndroidManifest.xml)
+     */
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        val apiKey = intent?.data?.getQueryParameter("apikey")
+        apiKey?.let { onApiKey(it) }
     }
 
     private fun setUpForgotPasswordBottomSheet() {
@@ -247,7 +275,8 @@ class LoginActivity : BaseAppCompatActivity() {
             SLApiService.fetchUserInfo(enteredApiKey) { result ->
                 runOnUiThread {
                     setLoading(false)
-                    result.onSuccess { finalizeLogin(enteredApiKey) }
+                    SLSharedPreferences.setApiKey(this, enteredApiKey)
+                    result.onSuccess { finalizeLogin(it) }
                     result.onFailure(::toastThrowable)
                 }
             }
@@ -318,7 +347,7 @@ class LoginActivity : BaseAppCompatActivity() {
             RC_MFA_VERIFICATION ->
                 if (resultCode == Activity.RESULT_OK) {
                     val apiKey = data?.getStringExtra(VerificationActivity.API_KEY)
-                    apiKey?.let { finalizeLogin(it) }
+                    apiKey?.let { onApiKey(it) }
                 }
 
             RC_EMAIL_VERIFICATION ->
@@ -388,6 +417,20 @@ class LoginActivity : BaseAppCompatActivity() {
         }
     }
 
+    private fun loginWithProton() {
+        dismissKeyboard()
+        val baseUrl = SLSharedPreferences.getApiUrl(this)
+        val url = "${baseUrl}/auth/proton/login?mode=apikey"
+
+        val builder = CustomTabsIntent.Builder()
+            .setDefaultColorSchemeParams(CustomTabColorSchemeParams.Builder()
+                .setToolbarColor(R.color.protonMain)
+                .build())
+
+        val customTabsIntent = builder.build()
+        customTabsIntent.launchUrl(this, Uri.parse(url))
+    }
+
     private fun setLoading(loading: Boolean) {
         binding.rootLinearLayout.customSetEnabled(!loading)
         binding.progressBar.visibility = if (loading) View.VISIBLE else View.GONE
@@ -399,12 +442,24 @@ class LoginActivity : BaseAppCompatActivity() {
                 startVerificationActivity(VerificationMode.Mfa(MfaKey(it)))
             }
 
-            false -> userLogin.apiKey?.let { finalizeLogin(it) }
+            false -> userLogin.apiKey?.let { onApiKey(userLogin.apiKey) }
         }
     }
 
-    private fun finalizeLogin(apiKey: String) {
+    private fun onApiKey(apiKey: String) {
         SLSharedPreferences.setApiKey(this, apiKey)
+        SLApiService.fetchUserInfo(apiKey) { result ->
+            result.onSuccess(::finalizeLogin)
+            result.onFailure(::toastThrowable)
+        }
+    }
+
+    private fun finalizeLogin(userInfo: UserInfo) {
+        val intent = Intent(this, HomeActivity::class.java)
+        intent.putExtra(HomeActivity.USER_INFO, userInfo)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        overridePendingTransition(R.anim.slide_in_up, R.anim.stay_still)
         finish()
     }
 

--- a/SimpleLogin/app/src/main/res/color/sl_sign_in_text_color_state.xml
+++ b/SimpleLogin/app/src/main/res/color/sl_sign_in_text_color_state.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorPrimary" android:state_enabled="true"/>
+    <item android:color="@color/colorDarkGray" android:state_enabled="false"/>
+</selector>

--- a/SimpleLogin/app/src/main/res/drawable/button_border_proton.xml
+++ b/SimpleLogin/app/src/main/res/drawable/button_border_proton.xml
@@ -1,0 +1,15 @@
+<ripple xmlns:android="http://schemas.android.com/apk/res/android" android:color="?colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <corners android:radius="@dimen/margin_8"/>
+            <solid android:color="@color/rippleColor"/>
+        </shape>
+    </item>
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="2dp"/>
+            <solid android:color="@color/colorItemBackground"/>
+            <stroke android:color="@color/protonMain" android:width="2dp"/>
+        </shape>
+    </item>
+</ripple>

--- a/SimpleLogin/app/src/main/res/drawable/button_border_sl.xml
+++ b/SimpleLogin/app/src/main/res/drawable/button_border_sl.xml
@@ -1,0 +1,15 @@
+<ripple xmlns:android="http://schemas.android.com/apk/res/android" android:color="?colorControlHighlight">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle">
+            <corners android:radius="@dimen/margin_8"/>
+            <solid android:color="@color/rippleColor"/>
+        </shape>
+    </item>
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <corners android:radius="2dp"/>
+            <solid android:color="@color/colorItemBackground"/>
+            <stroke android:color="@color/sl_sign_in_text_color_state" android:width="2dp"/>
+        </shape>
+    </item>
+</ripple>

--- a/SimpleLogin/app/src/main/res/drawable/ic_proton.xml
+++ b/SimpleLogin/app/src/main/res/drawable/ic_proton.xml
@@ -1,0 +1,38 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="12dp"
+    android:height="16dp"
+    android:viewportWidth="317"
+    android:viewportHeight="400">
+  <group>
+    <clip-path
+        android:pathData="M0,0h316.02v399.37h-316.02z"/>
+    <path
+        android:pathData="M-0,295.38V399.38H73V299.89C73,290.21 76.85,280.92 83.69,274.08C90.54,267.23 99.82,263.39 109.5,263.39H184.35C201.64,263.39 218.77,259.98 234.74,253.37C250.72,246.75 265.24,237.05 277.47,224.82C289.69,212.59 299.39,198.07 306.01,182.1C312.63,166.12 316.03,148.99 316.03,131.7C316.03,114.41 312.63,97.28 306.01,81.3C299.4,65.32 289.7,50.81 277.47,38.58C265.24,26.35 250.72,16.64 234.75,10.03C218.77,3.41 201.64,-0 184.35,-0H-0V130H73V68.7H179.41C195.93,68.7 211.78,75.26 223.47,86.95C235.15,98.63 241.72,114.48 241.72,131C241.72,147.52 235.15,163.37 223.47,175.06C211.79,186.74 195.94,193.31 179.41,193.31H102.04C88.64,193.3 75.36,195.94 62.98,201.07C50.59,206.2 39.34,213.72 29.86,223.2C20.39,232.68 12.87,243.93 7.75,256.32C2.62,268.7 -0.01,281.98 -0,295.38Z">
+      <aapt:attr name="android:fillColor">
+        <gradient 
+            android:centerX="317.15"
+            android:centerY="-55.45"
+            android:gradientRadius="401.97"
+            android:type="radial">
+          <item android:offset="0" android:color="#FFA995FF"/>
+          <item android:offset="1" android:color="#FF6652F5"/>
+        </gradient>
+      </aapt:attr>
+    </path>
+    <path
+        android:pathData="M109.48,263.38C95.1,263.38 80.87,266.21 67.58,271.71C54.3,277.21 42.23,285.28 32.06,295.44C21.9,305.61 13.83,317.68 8.33,330.96C2.83,344.24 -0,358.48 -0,372.86V399.37H73V299.88C73,290.2 76.84,280.92 83.68,274.08C90.52,267.23 99.8,263.39 109.48,263.38Z">
+      <aapt:attr name="android:fillColor">
+        <gradient 
+            android:startX="54.74"
+            android:startY="379.7"
+            android:endX="54.74"
+            android:endY="226.88"
+            android:type="linear">
+          <item android:offset="0" android:color="#FF6D4BFD"/>
+          <item android:offset="1" android:color="#FF1C0554"/>
+        </gradient>
+      </aapt:attr>
+    </path>
+  </group>
+</vector>

--- a/SimpleLogin/app/src/main/res/layout/activity_login.xml
+++ b/SimpleLogin/app/src/main/res/layout/activity_login.xml
@@ -73,16 +73,44 @@
                             android:textColor="@color/colorText" />
                     </com.google.android.material.textfield.TextInputLayout>
 
-                    <com.google.android.material.button.MaterialButton
+                    <androidx.appcompat.widget.AppCompatButton
                         android:id="@+id/loginButton"
-                        android:layout_width="wrap_content"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
                         android:layout_marginTop="8dp"
-                        android:padding="12dp"
+                        android:elevation="0dp"
                         android:text="Sign in"
-                        android:textColor="@color/btn_text_color_state"
+                        android:background="@color/colorPrimary"
+                        android:textColor="@color/colorWhite"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginEnd="16dp"
                         tools:ignore="HardcodedText" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="or"
+                        android:layout_gravity="center"
+                        android:layout_marginTop="4dp"
+                        tools:ignore="HardcodedText" />
+
+                    <androidx.appcompat.widget.AppCompatButton
+                        android:id="@+id/loginWithProtonButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:layout_marginTop="8dp"
+                        android:elevation="0dp"
+                        android:text="Log in with Proton"
+                        android:textColor="@color/protonMain"
+                        android:background="@drawable/button_border_proton"
+                        android:drawableStart="@drawable/ic_proton"
+                        android:layout_marginStart="16dp"
+                        android:layout_marginEnd="16dp"
+                        android:paddingStart="20dp"
+                        android:paddingEnd="20dp"
+                        tools:ignore="HardcodedText"/>
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/SimpleLogin/app/src/main/res/layout/activity_login.xml
+++ b/SimpleLogin/app/src/main/res/layout/activity_login.xml
@@ -78,13 +78,12 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:layout_marginTop="8dp"
+                        android:layout_marginTop="24dp"
                         android:elevation="0dp"
                         android:text="Sign in"
                         android:background="@color/colorPrimary"
                         android:textColor="@color/colorWhite"
-                        android:layout_marginStart="16dp"
-                        android:layout_marginEnd="16dp"
+
                         tools:ignore="HardcodedText" />
 
                     <TextView
@@ -106,8 +105,6 @@
                         android:textColor="@color/protonMain"
                         android:background="@drawable/button_border_proton"
                         android:drawableStart="@drawable/ic_proton"
-                        android:layout_marginStart="16dp"
-                        android:layout_marginEnd="16dp"
                         android:paddingStart="20dp"
                         android:paddingEnd="20dp"
                         tools:ignore="HardcodedText"/>
@@ -116,6 +113,7 @@
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:layout_marginTop="8dp"
                         android:weightSum="2">
 
                         <com.google.android.material.button.MaterialButton

--- a/SimpleLogin/app/src/main/res/values/colors.xml
+++ b/SimpleLogin/app/src/main/res/values/colors.xml
@@ -19,4 +19,5 @@
     <color name="rippleColor">#EBEBEB</color>
     <color name="dividerColor">#DBDCE0</color>
     <color name="switchTrackColor">#C0C1C3</color>
+    <color name="protonMain">#6D4AFF</color>
 </resources>


### PR DESCRIPTION
:warning: Do not generate a new release until this PR has been deployed to production: https://github.com/simple-login/app/pull/1186

This PR implements the following changes:

1. Add the `androidx.browser:browser` dependency for opening Custom Chrome tabs.
2. Add a new "Log in with Proton" button to the Login activity.
3. UI tweaks to the Login page.
4. Fix a bug that closed the app on any successful login. Now the user is redirected to the main (Home) activity when a successful login occurs.