### PR TITLE
Connect with Proton

### DIFF
--- a/SimpleLogin/app/src/main/AndroidManifest.xml
+++ b/SimpleLogin/app/src/main/AndroidManifest.xml
@@ -52,7 +52,21 @@
         <activity
             android:name=".module.home.HomeActivity"
             android:theme="@style/HomeActivityTheme"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+
+                <data
+                    android:scheme="@string/simplelogin_scheme"
+                    android:host="*"
+                    android:path="/link"
+                    />
+            </intent-filter>
+        </activity>
         <activity android:name=".module.startup.LocalAuthActivity" />
 
         <!--
@@ -67,7 +81,11 @@
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
 
-                <data android:scheme="auth.simplelogin"/>
+                <data
+                    android:scheme="@string/simplelogin_scheme"
+                    android:host="*"
+                    android:path="/login"
+                    />
             </intent-filter>
         </activity>
         <activity android:name=".module.login.VerificationActivity" />

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/home/HomeActivity.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/home/HomeActivity.kt
@@ -22,8 +22,10 @@ import com.google.android.material.navigation.NavigationView
 import io.simplelogin.android.R
 import io.simplelogin.android.databinding.ActivityHomeBinding
 import io.simplelogin.android.module.about.AboutFragment
+import io.simplelogin.android.module.settings.SettingsFragment
 import io.simplelogin.android.module.settings.view.AvatarView
 import io.simplelogin.android.module.startup.StartupActivity
+import io.simplelogin.android.utils.SLApiService
 import io.simplelogin.android.utils.SLSharedPreferences
 import io.simplelogin.android.utils.baseclass.BaseAppCompatActivity
 import io.simplelogin.android.utils.extension.getVersionName
@@ -67,6 +69,19 @@ class HomeActivity : BaseAppCompatActivity(), NavigationView.OnNavigationItemSel
         val userInfo = intent.getParcelableExtra(USER_INFO) as? UserInfo
             ?: throw IllegalStateException("UserInfo can not be null")
         viewModel.setUserInfo(userInfo)
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        // In case we received a new intent is because the Connect with Proton worked
+        // Refresh the user info
+        if (supportFragmentManager.fragments.size == 0) return
+        val navHostFragment = supportFragmentManager.fragments[0] as? NavHostFragment ?: return
+        val settingsFragment = navHostFragment.childFragmentManager.fragments.find { it is SettingsFragment }
+        if (settingsFragment != null) {
+            val casted = settingsFragment as SettingsFragment
+            casted.onNewIntent(intent)
+        }
     }
 
     override fun onBackPressed() {

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/home/HomeViewModel.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/home/HomeViewModel.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import io.simplelogin.android.utils.SLApiService
+import io.simplelogin.android.utils.enums.SLError
 import io.simplelogin.android.utils.model.UserInfo
 
 class HomeViewModel(application: Application) : AndroidViewModel(application) {

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/LoginActivity.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/login/LoginActivity.kt
@@ -10,13 +10,12 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.View
-import androidx.browser.customtabs.CustomTabColorSchemeParams
-import androidx.browser.customtabs.CustomTabsIntent
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import io.simplelogin.android.R
 import io.simplelogin.android.databinding.ActivityLoginBinding
 import io.simplelogin.android.module.home.HomeActivity
+import io.simplelogin.android.utils.LoginWithProtonUtils
 import io.simplelogin.android.utils.SLApiService
 import io.simplelogin.android.utils.SLSharedPreferences
 import io.simplelogin.android.utils.baseclass.BaseAppCompatActivity
@@ -413,16 +412,7 @@ class LoginActivity : BaseAppCompatActivity() {
 
     private fun loginWithProton() {
         dismissKeyboard()
-        val baseUrl = SLSharedPreferences.getApiUrl(this)
-        val url = "${baseUrl}/auth/proton/login?mode=apikey"
-
-        val builder = CustomTabsIntent.Builder()
-            .setDefaultColorSchemeParams(CustomTabColorSchemeParams.Builder()
-                .setToolbarColor(R.color.protonMain)
-                .build())
-
-        val customTabsIntent = builder.build()
-        customTabsIntent.launchUrl(this, Uri.parse(url))
+        LoginWithProtonUtils.launchLoginWithProton(this)
     }
 
     private fun setLoading(loading: Boolean) {

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/settings/SettingsFragment.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/settings/SettingsFragment.kt
@@ -120,8 +120,9 @@ class SettingsFragment : BaseFragment(), HomeActivity.OnBackPressed {
         }
 
         binding.connectWithProtonCardView.setOnUnlinkButtonClickListener {
-            // TODO: Add confirmation dialog
-            viewModel.unlinkProtonAccount()
+            alertUnlinkProtonAccount {
+                viewModel.unlinkProtonAccount()
+            }
         }
     }
 
@@ -264,6 +265,15 @@ class SettingsFragment : BaseFragment(), HomeActivity.OnBackPressed {
                     }
                 }
                 .show()
+    }
+
+    private fun alertUnlinkProtonAccount(onConfirm: () -> Unit) {
+        MaterialAlertDialogBuilder(requireContext(), R.style.SlAlertDialogTheme)
+            .setTitle(R.string.proton_unlink_account_confirmation_title)
+            .setMessage(R.string.proton_unlink_account_confirmation_content)
+            .setNegativeButton(R.string.dialog_cancel_button, null)
+            .setPositiveButton(R.string.dialog_confirm_button) { _, _ -> onConfirm()}
+            .show()
     }
 
     private fun askForPhotoLibraryPermission() {

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/module/settings/view/ConnectWithProtonView.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/module/settings/view/ConnectWithProtonView.kt
@@ -1,0 +1,51 @@
+package io.simplelogin.android.module.settings.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.RelativeLayout
+import androidx.core.content.ContextCompat
+import io.simplelogin.android.R
+import io.simplelogin.android.databinding.LayoutConnectWithProtonViewBinding
+
+class ConnectWithProtonView: RelativeLayout {
+    // Initializer
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    private val binding =
+        LayoutConnectWithProtonViewBinding.inflate(LayoutInflater.from(context), this, true)
+
+    init {
+        background = ContextCompat.getDrawable(context, android.R.color.transparent)
+    }
+
+    fun bind(connectedProtonAddress: String?) {
+        if (connectedProtonAddress != null) {
+            binding.connectWithProtonButton.visibility = View.GONE
+            binding.unlinkProtonAccountButton.visibility = View.VISIBLE
+            binding.connectWithProtonInfoText.visibility = View.GONE
+            binding.accountConnectedWithProtonText.visibility = View.VISIBLE
+            binding.accountConnectedWithProtonText.text = context.getString(R.string.currently_linked_proton_account, connectedProtonAddress)
+        } else {
+            binding.connectWithProtonButton.visibility = View.VISIBLE
+            binding.unlinkProtonAccountButton.visibility = View.GONE
+            binding.connectWithProtonInfoText.visibility = View.VISIBLE
+            binding.accountConnectedWithProtonText.visibility = View.GONE
+        }
+    }
+
+    fun setOnConnectButtonClickListener(listener: () -> Unit) {
+        binding.connectWithProtonButton.setOnClickListener {
+            listener()
+        }
+    }
+
+    fun setOnUnlinkButtonClickListener(listener: () -> Unit) {
+        binding.unlinkProtonAccountButton.setOnClickListener {
+            listener()
+        }
+    }
+}

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/LoginWithProtonUtils.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/LoginWithProtonUtils.kt
@@ -1,0 +1,40 @@
+package io.simplelogin.android.utils
+
+import android.content.Context
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabColorSchemeParams
+import androidx.browser.customtabs.CustomTabsIntent
+import io.simplelogin.android.R
+import io.simplelogin.android.utils.model.TemporaryToken
+
+
+object LoginWithProtonUtils {
+    fun launchLoginWithProton(context: Context) {
+        val baseUrl = SLSharedPreferences.getApiUrl(context)
+        val scheme = context.getString(R.string.simplelogin_scheme)
+        val next = "/login"
+        val url = "${baseUrl}/auth/proton/login?mode=apikey&action=login&scheme=${scheme}&next=${next}"
+        launchChromeTab(context, url)
+    }
+
+    fun launchLinkWithProton(context: Context, temporaryToken: TemporaryToken) {
+        val baseUrl = SLSharedPreferences.getApiUrl(context)
+        val scheme = context.getString(R.string.simplelogin_scheme)
+        val action = "link"
+        val next = "/link"
+        val nextQuery = "/auth/proton/login?action=${action}&next=${next}&scheme=${scheme}"
+        val nextQueryEncoded = Uri.encode(nextQuery)
+        val url = "${baseUrl}/auth/api_to_cookie?token=${temporaryToken.token}&next=${nextQueryEncoded}"
+        launchChromeTab(context, url)
+    }
+
+    private fun launchChromeTab(context: Context, url: String) {
+        val builder = CustomTabsIntent.Builder()
+            .setDefaultColorSchemeParams(CustomTabColorSchemeParams.Builder()
+                .setToolbarColor(R.color.protonMain)
+                .build())
+
+        val customTabsIntent = builder.build()
+        customTabsIntent.launchUrl(context, Uri.parse(url))
+    }
+}

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/extension/Fragment.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/extension/Fragment.kt
@@ -5,3 +5,9 @@ import androidx.fragment.app.Fragment
 
 fun Fragment.copyToClipboard(label: String, text: String) : Boolean =
     (activity as? AppCompatActivity)?.copyToClipboard(label, text) ?: false
+
+fun Fragment?.runOnUiThread(action: () -> Unit) {
+    this ?: return
+    if (!isAdded) return // Fragment not attached to an Activity
+    activity?.runOnUiThread(action)
+}

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/model/TemporaryToken.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/model/TemporaryToken.kt
@@ -1,0 +1,7 @@
+package io.simplelogin.android.utils.model
+
+import com.google.gson.annotations.SerializedName
+
+data class TemporaryToken(
+    @SerializedName("token") val token: String
+)

--- a/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/model/UserInfo.kt
+++ b/SimpleLogin/app/src/main/java/io/simplelogin/android/utils/model/UserInfo.kt
@@ -10,5 +10,6 @@ data class UserInfo(
     @SerializedName("email") val email: String,
     @SerializedName("profile_picture_url") val profilePhotoUrl: String?,
     @SerializedName("is_premium") val isPremium: Boolean,
-    @SerializedName("in_trial") val inTrial: Boolean
+    @SerializedName("in_trial") val inTrial: Boolean,
+    @SerializedName("connected_proton_address") val connectedProtonAddress: String?
 ) : Parcelable

--- a/SimpleLogin/app/src/main/res/layout/fragment_settings.xml
+++ b/SimpleLogin/app/src/main/res/layout/fragment_settings.xml
@@ -52,6 +52,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 
+                <io.simplelogin.android.module.settings.view.ConnectWithProtonView
+                    android:id="@+id/connect_with_proton_card_view"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
                 <io.simplelogin.android.module.settings.view.ForceDarkModeCardView
                     android:id="@+id/force_dark_mode_card_view"
                     android:layout_width="match_parent"

--- a/SimpleLogin/app/src/main/res/layout/layout_connect_with_proton_view.xml
+++ b/SimpleLogin/app/src/main/res/layout/layout_connect_with_proton_view.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="10dp"
+        android:layout_marginTop="10dp"
+        android:layout_marginBottom="5dp"
+        android:padding="@dimen/margin_15"
+        android:background="@drawable/card_shape_with_ripple"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/connectWithProtonButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="8dp"
+            android:elevation="0dp"
+            android:textColor="@color/protonMain"
+            android:background="@drawable/button_border_proton"
+            android:drawableStart="@drawable/ic_proton"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:text="@string/proton_link_account" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/unlinkProtonAccountButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="8dp"
+            android:elevation="0dp"
+            android:textColor="@color/protonMain"
+            android:background="@drawable/button_border_proton"
+            android:drawableStart="@drawable/ic_proton"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:visibility="gone"
+            android:text="@string/proton_unlink_account"/>
+
+        <TextView
+            android:id="@+id/connectWithProtonInfoText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/connect_with_proton_info_text"
+            android:paddingTop="8dp" />
+
+        <TextView
+            android:id="@+id/accountConnectedWithProtonText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="8dp"
+            android:visibility="gone" />
+
+    </LinearLayout>
+</layout>

--- a/SimpleLogin/app/src/main/res/values/strings.xml
+++ b/SimpleLogin/app/src/main/res/values/strings.xml
@@ -56,10 +56,14 @@
     <string name="simple_login_logo">SimpleLogin logo</string>
 
     <!-- Proton -->
-    <string name="proton_link_account">Unlink Proton account</string>
+    <string name="proton_link_account">Connect with Proton</string>
     <string name="proton_unlink_account">Unlink Proton account</string>
     <string name="your_proton_account_has_been_linked">Your Proton account has been successfully linked</string>
     <string name="your_proton_account_has_been_unlinked">Your Proton account has been unlinked</string>
     <string name="connect_with_proton_info_text">You can connect your Proton and SimpleLogin accounts.\nYou can then quickly log in to your SimpleLogin account using the Proton one.\n\nIf you have Proton Unlimited, Business or Visionary, you can have SimpleLogin premium for free.</string>
     <string name="currently_linked_proton_account">Your account is currently linked to the Proton account %s</string>
+    <string name="proton_unlink_account_confirmation_title">@string/proton_unlink_account</string>
+    <string name="proton_unlink_account_confirmation_content">Do you really want to unlink your Proton account?</string>
+    <string name="dialog_confirm_button">Confirm</string>
+    <string name="dialog_cancel_button">Cancel</string>
 </resources>

--- a/SimpleLogin/app/src/main/res/values/strings.xml
+++ b/SimpleLogin/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">SimpleLogin</string>
+    <string name="simplelogin_scheme" translatable="false">auth.simplelogin</string>
     <string name="facebook_app_id">388804475105146</string>
     <string name="fb_login_protocol_scheme">fb388804475105146</string>
     <string name="google_web_client_id">1015607994815-spepahv667u0o9f17nie3f9vuddhgp1p.apps.googleusercontent.com</string>
@@ -53,4 +54,12 @@
     <string name="sender_address_format_explication">Configure how incoming emails are formatted</string>
     <string name="sender_address_format_example">John Doe who uses john.doe@example.com to send you an email, how would you like to format his email?</string>
     <string name="simple_login_logo">SimpleLogin logo</string>
+
+    <!-- Proton -->
+    <string name="proton_link_account">Unlink Proton account</string>
+    <string name="proton_unlink_account">Unlink Proton account</string>
+    <string name="your_proton_account_has_been_linked">Your Proton account has been successfully linked</string>
+    <string name="your_proton_account_has_been_unlinked">Your Proton account has been unlinked</string>
+    <string name="connect_with_proton_info_text">You can connect your Proton and SimpleLogin accounts.\nYou can then quickly log in to your SimpleLogin account using the Proton one.\n\nIf you have Proton Unlimited, Business or Visionary, you can have SimpleLogin premium for free.</string>
+    <string name="currently_linked_proton_account">Your account is currently linked to the Proton account %s</string>
 </resources>


### PR DESCRIPTION
:warning: This PR depends on this backend PR to be deployed: https://github.com/simple-login/app/pull/1230

This PR implements the "Connect with Proton" button in the settings fragment.

It also moves the "Login with Proton" ChromeTab launch actions to an external file so the code for launching the ChromeTab can be easily reused.