### PR TITLE
Added support for monochrome/themed icon

### DIFF
--- a/SimpleLogin/app/src/main/res/drawable-v24/ic_launcher_background.xml
+++ b/SimpleLogin/app/src/main/res/drawable-v24/ic_launcher_background.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <group android:scaleX="0.25216982"
+      android:scaleY="0.25216982"
+      android:translateX="-27.44151"
+      android:translateY="-5.773585">
+    <path
+        android:pathData="M429.26,393H220.09c-28.36,0 -51.34,-22.99 -51.34,-51.34V132.48c0,-28.36 22.99,-51.34 51.34,-51.34h209.18c28.36,0 51.34,22.99 51.34,51.34v209.18C480.61,370.01 457.62,393 429.26,393z">
+      <aapt:attr name="android:fillColor">
+        <gradient 
+            android:startY="156.7578"
+            android:startX="207.2282"
+            android:endY="332.7922"
+            android:endX="464.6591"
+            android:type="linear">
+          <item android:offset="0" android:color="#FFED2E7C"/>
+          <item android:offset="1" android:color="#FFA8288F"/>
+        </gradient>
+      </aapt:attr>
+    </path>
+  </group>
+</vector>

--- a/SimpleLogin/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/SimpleLogin/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -9,20 +9,6 @@
       android:translateX="-27.44151"
       android:translateY="-5.773585">
     <path
-        android:pathData="M429.26,393H220.09c-28.36,0 -51.34,-22.99 -51.34,-51.34V132.48c0,-28.36 22.99,-51.34 51.34,-51.34h209.18c28.36,0 51.34,22.99 51.34,51.34v209.18C480.61,370.01 457.62,393 429.26,393z">
-      <aapt:attr name="android:fillColor">
-        <gradient 
-            android:startY="156.7578"
-            android:startX="207.2282"
-            android:endY="332.7922"
-            android:endX="464.6591"
-            android:type="linear">
-          <item android:offset="0" android:color="#FFED2E7C"/>
-          <item android:offset="1" android:color="#FFA8288F"/>
-        </gradient>
-      </aapt:attr>
-    </path>
-    <path
         android:pathData="M261.61,172.25l-0.04,0.04h0.07L261.61,172.25z"
         android:fillColor="#FFFFFF"/>
     <path

--- a/SimpleLogin/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/SimpleLogin/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
+    <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/SimpleLogin/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/SimpleLogin/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/ic_launcher_background"/>
+    <background android:drawable="@drawable/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Fixes https://github.com/simple-login/Simple-Login-Android/issues/109 and https://github.com/simple-login/Simple-Login-Android/issues/108.
Before a simple green background was used as the app icon background. With this commit the pink background is used as the app icon background and the foreground is also used as a monochrome/themed icon. For more information on themed icons, see [adaptive icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive), section user theming.
![Screenshot_20230424-140551_Trebuchet](https://user-images.githubusercontent.com/115667885/233991917-87e0faa9-f473-419b-b8c4-07cac79daeef.png)
