### PR TITLE
Create dependabot.yml to ensure all GitHub Actions are kept up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every day
+      interval: "daily"


### PR DESCRIPTION
Some workflows in this repository use deprecated Node 12 GitHub Actions. Some examples are:
- `actions/checkout@v2` and `actions/create-release@v1` in `create-release`
- `actions/checkout@v2`, `actions/***-release-asset@v1.0.1` and `slackapi/slack-github-action@v1.19.0` in `build-release`

Those actions should be updated to their last version which uses Node 16 to avoid running old deprecated Node 12 Actions in Node 16 (for more information see [here](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)).

By configuring dependabot automatic PRs will be made to ensure all actions are kept up to date